### PR TITLE
Base detection fix

### DIFF
--- a/AkBot.Tests/AkBot.Tests.vcxproj
+++ b/AkBot.Tests/AkBot.Tests.vcxproj
@@ -134,13 +134,13 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;UNITTESTPRJ="$(ProjectDir)";NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
-      <AdditionalIncludeDirectories>$(BWAPI_DIR)/include;$(SolutionDir)..\..\UAlbertaBot\Source\;$(SolutionDir)TestLib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)../../UAlbertaBot/source;$(SolutionDir)../../AkBot.Tests/TestLib;$(SolutionDir)../../AkBot.Tests/Shared;$(BWAPI_DIR)/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(BWAPI_DIR)/lib/BWAPI.lib;$(Configuration)/SparCraft/SparCraft.lib;$(Configuration)/BOSS/BOSS.lib;../UAlbertaBot/bin/AKBot_lib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(BWAPI_DIR)/lib/BWAPI.lib;$(SolutionDir)$(Configuration)/SparCraft/SparCraft.lib;$(SolutionDir)$(Configuration)/BOSS/BOSS.lib;../UAlbertaBot/bin/AKBot_lib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -214,6 +214,7 @@
     <ClCompile Include="BaseLocationManagerTest.cpp" />
     <ClCompile Include="BotConfigurationTest.cpp" />
     <ClCompile Include="CommandManagerTest.cpp" />
+    <ClCompile Include="ExplorerManagerTest.cpp" />
     <ClCompile Include="NullLogger.cpp" />
     <ClCompile Include="Shared\BulletShared.cpp" />
     <ClCompile Include="Shared\ForceShared.cpp" />

--- a/AkBot.Tests/AkBot.Tests.vcxproj.filters
+++ b/AkBot.Tests/AkBot.Tests.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="CommandManagerTest.cpp">
       <Filter>commands</Filter>
     </ClCompile>
+    <ClCompile Include="ExplorerManagerTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">

--- a/AkBot.Tests/ExplorerManagerTest.cpp
+++ b/AkBot.Tests/ExplorerManagerTest.cpp
@@ -1,0 +1,80 @@
+#include "stdafx.h"
+#include "GameImpl.h"
+#include "ExplorerManager.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+template <typename Container>
+bool contains(Container const& c, typename Container::const_reference v) {
+	return std::find(c.begin(), c.end(), v) != c.end();
+}
+
+AKBot::ExplorationCheck alwaysExplored = [](const BWAPI::TilePosition& position) { return true; };
+AKBot::ExplorationCheck neverExplored = [](const BWAPI::TilePosition& position) { return false; };
+
+namespace AkBotTests
+{
+	using AKBot::ExplorerManager;
+
+	TEST_CLASS(ExplorerManagerTest)
+	{
+	public:
+
+		TEST_METHOD(FiveLocationsCheckedForEachBase)
+		{
+			ExplorerManager sut(neverExplored);
+
+			// Add base location to the search element
+			sut.addBaseLocation(BWAPI::TilePosition(10, 20));
+			// Should be added 5 elements for checking locations
+			Assert::AreEqual(5U, sut.locationsToCheckCount(), L"5 locations should be checked");
+		}
+
+		TEST_METHOD(AreaNearBaseShouldBeCheckedToIntroduceVariance)
+		{
+			ExplorerManager sut(neverExplored);
+
+			// Add base location to the search element
+			sut.addBaseLocation(BWAPI::TilePosition(10, 20));
+			// Should be added 5 elements for checking locations
+			Assert::AreEqual(5U, sut.locationsToCheckCount(), L"5 locations should be checked");
+			auto& locations = sut.locationsToCheck();
+			Assert::IsTrue(contains(locations, BWAPI::TilePosition(10, 20)), L"Base location should be marked for exploration");
+		}
+
+		TEST_METHOD(RegularPointOfInterestAddSingleLocation)
+		{
+			ExplorerManager sut(neverExplored);
+
+			// Add base location to the search element
+			sut.addLocation(BWAPI::TilePosition(10, 20));
+			// Should be added 5 elements for checking locations
+			Assert::AreEqual(1U, sut.locationsToCheckCount(), L"1 locations should be explored for regular location");
+		}
+
+		TEST_METHOD(AlreadyExploredLocationsDoesNotAdded)
+		{
+			ExplorerManager sut(alwaysExplored);
+
+			// Add base location to the search element
+			sut.addLocation(BWAPI::TilePosition(10, 20));
+			// Should be added 5 elements for checking locations
+			Assert::AreEqual(0U, sut.locationsToCheckCount(), L"1 locations should be explored for regular location");
+		}
+
+		TEST_METHOD(ExploredLocationsRemovedFromTargets)
+		{
+			bool isTargetExplored = false;
+			ExplorerManager sut([&isTargetExplored](const BWAPI::TilePosition& position) { return isTargetExplored; });
+
+			// Add base location to the search element
+			sut.addLocation(BWAPI::TilePosition(10, 20));
+			Assert::AreEqual(1U, sut.locationsToCheckCount(), L"1 locations should be not explored before runing verification");
+			
+			// Mark location as eplored.
+			isTargetExplored = true;
+			sut.verifyExpored();
+			Assert::AreEqual(0U, sut.locationsToCheckCount(), L"The location should be removed if it is explored");
+		}
+	};
+}

--- a/BOSS/VisualStudio/BOSS.vcxproj
+++ b/BOSS/VisualStudio/BOSS.vcxproj
@@ -102,7 +102,7 @@
     <ProjectGuid>{9F8709E3-AC4F-45F2-8105-4A99D8E2A127}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>StarcraftBuildOrderSearch</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/SparCraft/VisualStudio/SparCraft.vcxproj
+++ b/SparCraft/VisualStudio/SparCraft.vcxproj
@@ -38,7 +38,7 @@
     <ProjectGuid>{66236439-5968-4756-B2E7-8A29BEA99078}</ProjectGuid>
     <RootNamespace>StarcraftBuildOrderSearch</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/UAlbertaBot/Source/ExplorerManager.cpp
+++ b/UAlbertaBot/Source/ExplorerManager.cpp
@@ -1,0 +1,49 @@
+#include "ExplorerManager.h"
+
+AKBot::ExplorerManager::ExplorerManager(AKBot::ExplorationCheck explorationCheck)
+	: _locations(), _explorationCheck(explorationCheck)
+{
+}
+
+void AKBot::ExplorerManager::addBaseLocation(const BWAPI::TilePosition & position)
+{
+	// if we haven't explored it yet
+	// When we check just original depot tile position, this could lead to cases when scout reach the point
+	// and did not record fact that base is here. It is sometimes happens in the 3 player games.
+	// This is very significant error which lead to failure of discovery original enemy base.
+	// Possible workaround is create separate rule for checking if base location is explored 
+	// by exploring not single depot location, but instead any location near base, to be more confident.
+	// This lead to speed loss, but increase reliability.
+	addLocation(position);
+	addLocation(position + BWAPI::TilePosition(2, 2));
+	addLocation(position + BWAPI::TilePosition(-2, 2));
+	addLocation(position + BWAPI::TilePosition(2, -2));
+	addLocation(position + BWAPI::TilePosition(-2, -2));
+}
+
+void AKBot::ExplorerManager::addLocation(const BWAPI::TilePosition & position)
+{
+	if (_explorationCheck(position)) {
+		// Do nothing if we think that location is explored.
+		return;
+	}
+
+	// Add location to the list of items to explore if location still unexplored.
+	_locations.push_back(position);
+}
+
+const size_t AKBot::ExplorerManager::locationsToCheckCount() const
+{
+	return _locations.size();
+}
+
+const std::vector<BWAPI::TilePosition>& AKBot::ExplorerManager::locationsToCheck() const
+{
+	return _locations;
+}
+
+void AKBot::ExplorerManager::verifyExpored()
+{
+	auto eraseMarker = std::remove_if(_locations.begin(), _locations.end(), _explorationCheck);
+	_locations.erase(eraseMarker);
+}

--- a/UAlbertaBot/Source/ExplorerManager.h
+++ b/UAlbertaBot/Source/ExplorerManager.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <BWAPI\Position.h>
+#include <vector>
+#include <functional>
+
+namespace AKBot
+{
+	typedef std::function<bool(const BWAPI::TilePosition&)> ExplorationCheck;
+
+	class ExplorerManager
+	{
+		std::vector<BWAPI::TilePosition> _locations;
+		ExplorationCheck _explorationCheck;
+	public:
+		// Create new isntance of ExplorerManager with function performing check of tiles for exploration status.
+		ExplorerManager(ExplorationCheck explorationCheck);
+
+		// Adds base location for exploration by specify position of the base.
+		// This like regular location, but we want to add couple more points to check,
+		// to account for different base placement models
+		void addBaseLocation(const BWAPI::TilePosition& position);
+		
+		// Add regular location for exploration
+		// Difference between regular location and base location is that no base-specific optimization is added
+		void addLocation(const BWAPI::TilePosition& position);
+
+		// Gets count of elements which are currenly pending explorations
+		const size_t locationsToCheckCount() const;
+
+		// Locations which should be explored.
+		const std::vector<BWAPI::TilePosition>& locationsToCheck() const;
+
+		// Verify status of target exploration points.
+		// If some of them already explored, remove them from the list.
+		void verifyExpored();
+	};
+}

--- a/UAlbertaBot/Source/ScoutManager.h
+++ b/UAlbertaBot/Source/ScoutManager.h
@@ -4,6 +4,7 @@
 #include "MicroManager.h"
 #include "UnitHandler.h"
 #include "BaseLocationManager.h"
+#include "ExplorerManager.h"
 
 namespace UAlbertaBot
 {
@@ -11,6 +12,7 @@ namespace UAlbertaBot
 
 class ScoutManager 
 {
+	ExplorerManager _explorerManager;
 	shared_ptr<BaseLocationManager> _baseLocationManager;
 	BWAPI::Unit     _workerScout;
     std::string     _scoutStatus;
@@ -33,8 +35,8 @@ class ScoutManager
 	BWAPI::Unit     closestEnemyWorker();
     //void            followPerimeter();
 	void            moveScouts(int currentFrame);
-	bool exploreEnemyBases(int currentFrame);
-	bool allEnemyBasesExplored() const;
+	bool updateExplorationTargets(int currentFrame);
+	bool nothingToExplore() const;
 	void harrasEnemyBaseIfPossible(const BaseLocation * enemyBaseLocation, int scoutHP, int currentFrame);
     //void            calculateEnemyRegionVertices();
 

--- a/UAlbertaBot/Source/debug/BaseLocationManagerDebug.cpp
+++ b/UAlbertaBot/Source/debug/BaseLocationManagerDebug.cpp
@@ -16,16 +16,62 @@ namespace AKBot
 	}
 	void BaseLocationManagerDebug::draw(AKBot::ScreenCanvas & canvas)
 	{
+		drawBases(canvas);
+		drawBasesSummary(canvas, 300, 100);
+		drawNextExpansion(canvas);
+	}
+
+	void BaseLocationManagerDebug::drawBases(AKBot::ScreenCanvas & canvas)
+	{
 		auto isBuildableTileCheck = [this](BWAPI::TilePosition tile)
 		{
 			return _map->isBuildableTile(tile);
 		};
 		for (auto baseLocation : _baseLocationManager->getBaseLocations())
 		{
-			// baseLocation->draw(canvas, isBuildableTileCheck);
 			drawBase(*baseLocation, canvas, isBuildableTileCheck);
 		}
+	}
 
+	void BaseLocationManagerDebug::drawBasesSummary(AKBot::ScreenCanvas & canvas, int x, int y)
+	{
+		canvas.drawTextScreen(x, y, "\x03 Id: \x1f Occupied By");
+		y += 12;
+		for (auto baseLocation : _baseLocationManager->getBaseLocations())
+		{
+			std::string owned;
+			bool firstLocation = true;
+			if (baseLocation->isOccupiedByPlayer(_opponentView->self())) {
+				if (firstLocation) {
+					owned = "me";
+					firstLocation = false;
+				}
+				else {
+					owned += ",me";
+				}
+			}
+
+			for (auto player : _opponentView->enemies()) {
+
+				if (baseLocation->isOccupiedByPlayer(player)) {
+					if (firstLocation) {
+						owned = player->getName();
+						firstLocation = false;
+					}
+					else {
+						owned += ",";
+						owned += player->getName();
+					}
+				}
+			}
+
+			canvas.drawTextScreen(x, y, "\x03 %d \x1f %s", baseLocation->getId(), owned.c_str());
+			y += 12;
+		}
+	}
+
+	void BaseLocationManagerDebug::drawNextExpansion(AKBot::ScreenCanvas & canvas)
+	{
 		auto self = _opponentView->self();
 		BWAPI::Position nextExpansionPosition(_baseLocationManager->getNextExpansion(self));
 

--- a/UAlbertaBot/Source/debug/BaseLocationManagerDebug.h
+++ b/UAlbertaBot/Source/debug/BaseLocationManagerDebug.h
@@ -28,6 +28,9 @@ namespace AKBot
 			shared_ptr<MapTools> map,
 			const BotDebugConfiguration& debugConfiguration);
 		void draw(AKBot::ScreenCanvas& canvas) override;
+		void drawNextExpansion(AKBot::ScreenCanvas & canvas);
+		void drawBases(AKBot::ScreenCanvas & canvas);
+		void drawBasesSummary(AKBot::ScreenCanvas & canvas, int x, int y);
 		void drawBase(const BaseLocation& base, AKBot::ScreenCanvas& canvas, std::function<bool(BWAPI::TilePosition tile)> isBuildableTile) const;
 	};
 }

--- a/UAlbertaBot/VisualStudio/AKBot.vcxproj
+++ b/UAlbertaBot/VisualStudio/AKBot.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\Source\DefaultPlayerLocationProvider.cpp" />
     <ClCompile Include="..\source\DetectorManager.cpp" />
     <ClCompile Include="..\Source\DistanceMap.cpp" />
+    <ClCompile Include="..\Source\ExplorerManager.cpp" />
     <ClCompile Include="..\Source\GameCommander.cpp" />
     <ClCompile Include="..\Source\ScreenCanvas.cpp" />
     <ClCompile Include="..\Source\strategies\BaseStrategyExecutor.cpp" />
@@ -150,6 +151,7 @@
     <ClInclude Include="..\source\DetectorManager.h" />
     <ClInclude Include="..\Source\Distance.h" />
     <ClInclude Include="..\Source\DistanceMap.h" />
+    <ClInclude Include="..\Source\ExplorerManager.h" />
     <ClInclude Include="..\Source\GameCommander.h" />
     <ClInclude Include="..\Source\GameHistory.hpp" />
     <ClInclude Include="..\Source\Logger.h" />

--- a/UAlbertaBot/VisualStudio/AKBot.vcxproj.filters
+++ b/UAlbertaBot/VisualStudio/AKBot.vcxproj.filters
@@ -238,6 +238,9 @@
     <ClCompile Include="..\Source\commands\MicroCommandExecutor.cpp">
       <Filter>commands</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\ExplorerManager.cpp">
+      <Filter>macro</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="common">
@@ -561,6 +564,9 @@
     </ClInclude>
     <ClInclude Include="..\Source\commands\MicroCommandExecutor.h">
       <Filter>commands</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\ExplorerManager.h">
+      <Filter>macro</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add explorere manager which maintain list of locations to explore
Right now the exploration is checked only based on BWAPI, but later it could be changed to take time when location was explored into account.
- Check not only base location, but also near locations, to be more reliable in rare cases when base location located in not good location and we did not capture enemy discovery