### PR TITLE
Correct location of the enemy base

### DIFF
--- a/UAlbertaBot/Source/UnitInfoManager.cpp
+++ b/UAlbertaBot/Source/UnitInfoManager.cpp
@@ -48,7 +48,15 @@ const std::map<int, UnitInfo> & UnitInfoManager::getUnitInfoMap(BWAPI::Player pl
 
 bool UnitInfoManager::isEnemyUnit(BWAPI::Unit unit)
 {
-	return unit->getPlayer() == _opponentView->defaultEnemy();
+	for (auto const& enemyPlayer : _opponentView->enemies())
+	{
+		if (unit->getPlayer()->getID() == enemyPlayer->getID())
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 void UnitInfoManager::updateUnit(BWAPI::Unit unit)


### PR DESCRIPTION
Don't skip looking for units of the non first enemy in the list.
This lead to cases when location of secondary player to be attacked to late in the game, even if it was discovered.