### PR TITLE
Display last game frame

### DIFF
--- a/UAlbertaBot/Source/BotPlayer.cpp
+++ b/UAlbertaBot/Source/BotPlayer.cpp
@@ -36,5 +36,5 @@ void BotPlayer::PlayGame()
 		}
 	}
 
-	std::cout << "Game Over\n";
+	std::cout << "Game Over at frame " << BWAPI::Broodwar->getFrameCount() << std::endl;
 }


### PR DESCRIPTION
When launching game using EXE connector, on the game end display last frame number, so later that value could be analyzed. For example when I will optimize for the faster enemy elimination