### PR TITLE
Don't account invisible units for simulation

### DIFF
--- a/AkBot.Tests/AkBot.Tests.vcxproj
+++ b/AkBot.Tests/AkBot.Tests.vcxproj
@@ -233,6 +233,7 @@
     <ClCompile Include="TestLib\RegionImpl.cpp" />
     <ClCompile Include="TestLib\UnitImpl.cpp" />
     <ClCompile Include="UnitHelper.cpp" />
+    <ClCompile Include="UnitInfoManagerTest.cpp" />
     <ClCompile Include="unittest1.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/AkBot.Tests/AkBot.Tests.vcxproj.filters
+++ b/AkBot.Tests/AkBot.Tests.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="RangedManagerTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UnitInfoManagerTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">

--- a/AkBot.Tests/GameHelper.cpp
+++ b/AkBot.Tests/GameHelper.cpp
@@ -37,6 +37,13 @@ void AKBot::Tests::setPlayers(BWAPI::GameData& gameData, int playersCount)
 	for (auto i = 0; i < playersCount; i++)
 	{
 		strcpy_s(gameData.players[i].name, playerNames[i]);
+		for (auto j = 0; j < playersCount; j++)
+		{
+			if (j != i)
+			{
+				gameData.players[i].isEnemy[j] = true;
+			}
+		}
 	}
 
 	gameData.players[playersCount].isNeutral = true;

--- a/AkBot.Tests/UnitHelper.cpp
+++ b/AkBot.Tests/UnitHelper.cpp
@@ -15,6 +15,7 @@ void AKBot::Tests::placeGeyser(BWAPI::UnitData& unitData, int x, int y, int reso
 	unitData.positionY = y;
 	unitData.type = BWAPI::UnitTypes::Resource_Vespene_Geyser;
 	unitData.exists = true;
+	unitData.isCompleted = true;
 	unitData.resources = resources;
 }
 void AKBot::Tests::placeTerrainBunker(BWAPI::UnitData& unitData, int x, int y)
@@ -41,4 +42,5 @@ void AKBot::Tests::placeUnit(BWAPI::UnitData& unitData, BWAPI::UnitType unitType
 	unitData.hitPoints = unitType.maxHitPoints();
 	unitData.shields = unitType.maxShields();
 	unitData.exists = true;
+	unitData.isCompleted = true;
 }

--- a/AkBot.Tests/UnitInfoManagerTest.cpp
+++ b/AkBot.Tests/UnitInfoManagerTest.cpp
@@ -1,0 +1,68 @@
+#include "stdafx.h"
+#include "GameImpl.h"
+#include "UnitInfoManager.h"
+#include "BWAPIOpponentView.h"
+#include "UnitHelper.h"
+#include "GameHelper.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace AKBot::Tests;
+
+namespace AkBotTests
+{
+	using UAlbertaBot::UnitInfoManager;
+	using UAlbertaBot::UnitInfo;
+	using AKBot::BWAPIOpponentView;
+
+	TEST_CLASS(UnitInfoManagerTest)
+	{
+	public:
+		UnitInfoManagerTest()
+		{
+		}
+		~UnitInfoManagerTest()
+		{
+			BWAPI::BroodwarPtr = nullptr;
+		}
+		TEST_METHOD(InvisibleUnitsDoesNotCountedDuringTesting)
+		{
+			auto gameData = std::make_shared<BWAPI::GameData>();
+			auto rawGameData = gameData.get();
+			
+			placeZergZergeling(gameData->units[0], 100, 100);
+			gameData->units[0].player = 1;
+			gameData->units[0].isVisible[0] = true;
+			gameData->events[0].type = BWAPI::EventType::UnitDiscover;
+			gameData->events[0].v1 = 0;
+			gameData->eventCount++;
+			placeZergZergeling(gameData->units[1], 100, 120);
+			gameData->units[1].player = 1;
+			gameData->units[1].isVisible[0] = false;
+			gameData->events[1].type = BWAPI::EventType::UnitDiscover;
+			gameData->events[1].v1 = 1;
+			gameData->eventCount++;
+
+			setP2PForces(rawGameData);
+			rawGameData->self = 0;
+			rawGameData->enemy = 1;
+			setPlayers(*rawGameData, 2);
+
+			auto gameImpl = std::make_shared<AKBot::GameImpl>(gameData.get());
+			auto game = gameImpl.get();
+			BWAPI::BroodwarPtr = game;
+			auto opponentView = std::make_shared<BWAPIOpponentView>(game);
+			UnitInfoManager sut(opponentView);
+			game->onMatchStart();
+			game->onMatchFrame();
+			
+			sut.update();
+
+			// Add base location to the search element
+			std::vector<UnitInfo> targets;
+			sut.getNearbyForce(targets, BWAPI::Position(0,0), opponentView->defaultEnemy(), 100000);
+
+			// Should be added 0 elements for checking locations
+			Assert::AreEqual(1U, targets.size(), L"Just single visible unit counted");
+		}
+	};
+}

--- a/UAlbertaBot/Source/UnitInfoManager.cpp
+++ b/UAlbertaBot/Source/UnitInfoManager.cpp
@@ -112,6 +112,10 @@ void UnitInfoManager::getNearbyForce(std::vector<UnitInfo> & unitInfo, BWAPI::Po
 	for (const auto & kv : getUnitData(player).getUnitInfoMap())
 	{
 		const UnitInfo & ui(kv.second);
+
+		if (!ui.unit->isVisible()) {
+			continue;
+		}
         
 		// if it's a combat unit we care about
 		// and it's finished! 


### PR DESCRIPTION
When units leave game scene, sometimes some leftovers of them stay on the map. They could effectively block progress of the army, since they would be scary of "ghosts" and wait for additional reinforcements to arrive.