### PR TITLE
Extract queue operation which accept build orders

### DIFF
--- a/UAlbertaBot/Source/ProductionManager.h
+++ b/UAlbertaBot/Source/ProductionManager.h
@@ -43,12 +43,15 @@ class ProductionManager
 
     bool                meetsReservedResources(MetaType type);
     void                setBuildOrder(const BuildOrder & buildOrder);
+	void                queueAsLowestPriority(const BuildOrder & buildOrder);
+	void                queueAsHighestPriority(const BuildOrder & buildOrder);
     void                create(BWAPI::Unit producer,BuildOrderItem & item);
     void                manageBuildOrderQueue(int currentFrame);
     void                performCommand(BWAPI::UnitCommandType t);
     bool                canMakeNow(BWAPI::Unit producer,MetaType t);
     void                predictWorkerMovement(const Building & b);
-
+	BuildOrder			getDetectorBuildOrder();
+	BuildOrder			getQueueUnlockBuildOrder();
     bool                detectBuildOrderDeadlock();
 
     int                 getFreeMinerals();


### PR DESCRIPTION
That allow more clean expression of the intention.
Functions `ProductionManager::getDetectorBuildOrder` and `ProductionManager::getQueueUnlockBuildOrder` provide rudimentary reactions on the following events: "build deadlock" and "enemy cloack detected"