### PR TITLE
Fixed errors in the scouting

### DIFF
--- a/AkBot.Tests/ExplorerManagerTest.cpp
+++ b/AkBot.Tests/ExplorerManagerTest.cpp
@@ -69,3 +69,14 @@ BOOST_AUTO_TEST_CASE(ExploredLocationsRemovedFromTargets)
 	sut.verifyExpored();
 	BOOST_TEST(0U == sut.locationsToCheckCount(), L"The location should be removed if it is explored");
 }
+
+BOOST_AUTO_TEST_CASE(LocationAddedTwiceIgnored)
+{
+	ExplorerManager sut(neverExplored);
+
+	// Add base location to the search element
+	sut.addLocation(BWAPI::TilePosition(10, 20));
+	sut.addLocation(BWAPI::TilePosition(10, 20));
+	// Should be added 5 elements for checking locations
+	BOOST_TEST(1U == sut.locationsToCheckCount(), L"1 locations should be explored for regular location");
+}

--- a/UAlbertaBot/Source/ExplorerManager.cpp
+++ b/UAlbertaBot/Source/ExplorerManager.cpp
@@ -28,6 +28,13 @@ void AKBot::ExplorerManager::addLocation(const BWAPI::TilePosition & position)
 		return;
 	}
 
+	auto index = std::find(_locations.cbegin(), _locations.cend(), position);
+	if (index != _locations.cend())
+	{
+		// Skip already added location.
+		return;
+	}
+
 	// Add location to the list of items to explore if location still unexplored.
 	_locations.push_back(position);
 }

--- a/UAlbertaBot/Source/MapTools.cpp
+++ b/UAlbertaBot/Source/MapTools.cpp
@@ -20,7 +20,7 @@ MapTools::MapTools(shared_ptr<AKBot::MapInformation> mapInformation, std::shared
     , _walkable         (4 * mapInformation->getWidth(), std::vector<bool>(4 * mapInformation->getHeight(), false))
     , _buildable        (mapInformation->getWidth(), std::vector<bool>(mapInformation->getHeight(), true))
     , _depotBuildable   (mapInformation->getWidth(), std::vector<bool>(mapInformation->getHeight(), true))
-    , _lastSeen         (mapInformation->getWidth(), std::vector<int> (mapInformation->getHeight(), 0))
+    , _lastSeen         (mapInformation->getWidth(), std::vector<int> (mapInformation->getHeight(), std::numeric_limits<int>::min()))
     , _sectorNumber     (mapInformation->getWidth(), std::vector<int> (mapInformation->getHeight(), 0))
 	, _logger(logger)
 {

--- a/UAlbertaBot/Source/ScoutManager.cpp
+++ b/UAlbertaBot/Source/ScoutManager.cpp
@@ -35,7 +35,7 @@ void ScoutManager::update(int currentFrame)
     {
         calculateEnemyRegionVertices();
     }*/
-
+	_currentFrame = currentFrame;
 	moveScouts(currentFrame);
 }
 


### PR DESCRIPTION
- Prevent spawning of the duplicate exploration targets 
- Save curent frame number, for accessing in the verifyExplored
- Initialize lastSeen array with minimal int value, to always trigger exploration check