### PR TITLE
Ignore workers which too far from attacking units.

### DIFF
--- a/UAlbertaBot/Source/BotConfiguration.h
+++ b/UAlbertaBot/Source/BotConfiguration.h
@@ -131,7 +131,15 @@ struct BotMicroConfiguration
 	// Strategy for estimation of the combat results.
 	std::string CombatEstimationStrategy = "sparcraft";
 	int CombatEstimationDepth = 96; // Depth of combat simulation depth.
+
+	// Indicates that workers will be included into attacker force.
+	// Only workers closer then WorkerIgnoreDistance will be included.
 	bool IncludeWorkers = true;
+
+	// Distance starting from which workers will always will be ignored
+	// as attacing unit. Units which does not have bot units closer then specified
+	// amount will always be ignored during estimation process.
+	int WorkerIgnoreDistance = 64;
 };
 
 struct BotMacroConfiguration

--- a/UAlbertaBot/Source/ParseUtils.cpp
+++ b/UAlbertaBot/Source/ParseUtils.cpp
@@ -127,6 +127,7 @@ void UAlbertaBot::ParseUtils::ParseConfigFile(
 		JSONTools::ReadString("CombatEstimationStrategy", micro, microOptions.CombatEstimationStrategy);
 		JSONTools::ReadInt("CombatEstimationDepth", micro, microOptions.CombatEstimationDepth);
 		JSONTools::ReadBool("IncludeWorkers", micro, microOptions.IncludeWorkers);
+		JSONTools::ReadInt("WorkerIgnoreDistance", micro, microOptions.WorkerIgnoreDistance);
 
         if (micro.HasMember("KiteLongerRangedUnits") && micro["KiteLongerRangedUnits"].IsArray())
         {


### PR DESCRIPTION
This prevents attackers to be shy of workers on the map when `IncludeWorkers == true`
Such threshold allow do not fear small amount of workers, and only big wave would be a problem

Closes #35 